### PR TITLE
Use theme background color for Quick Settings sub options

### DIFF
--- a/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
@@ -120,7 +120,7 @@
 }
 
 .quick-toggle-menu-container {
-  & > StBoxLayout { background-color: $osd_bg_color !important; }
+  & > StBoxLayout { background-color: $osd_insensitive_bg_color !important; }
 }
 
 .quick-settings-system-item {

--- a/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
@@ -120,6 +120,7 @@
 }
 
 .quick-toggle-menu-container {
+  & > StBoxLayout { background-color: $osd_bg_color !important; }
 }
 
 .quick-settings-system-item {

--- a/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
@@ -120,7 +120,9 @@
 }
 
 .quick-toggle-menu-container {
-  & > StBoxLayout { background-color: $osd_insensitive_bg_color !important; }
+  & > StBoxLayout {
+    background-color: $bg_color !important;
+  }
 }
 
 .quick-settings-system-item {

--- a/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/44/gnome-shell-sass/widgets/_quick-settings.scss
@@ -121,6 +121,7 @@
 
 .quick-toggle-menu-container {
   & > StBoxLayout {
+    color: $fg_color !important;
     background-color: $bg_color !important;
   }
 }


### PR DESCRIPTION
This prevents the sub options for quick settings tiles from being left as GNOME's vanilla gray.

Edit: The default Adwaita theme uses the main background color for the quick settings subsections and not the OSD ones. Thus, switched to that and the main foreground color.