### PR TITLE
fix: inactive window background color

### DIFF
--- a/plugins/firefox_gnome_theme.py
+++ b/plugins/firefox_gnome_theme.py
@@ -14,6 +14,7 @@ TEMPLATE = """
  */
 
 :root {{
+    --gnome-window-background:                     {window_bg_color};
     --gnome-browser-before-load-background:        {window_bg_color};
     --gnome-accent-bg:                             {accent_bg_color};
     --gnome-accent:                                {accent_color};


### PR DESCRIPTION
Hi!

With recent changes to the Firefox GNOME theme, we just need to override `gnome-window-background` to match with Gradience's theme instead of using the default hard-coded value. This fixes the issue shown in the following clip:

[Kooha-2023-10-05-22-34-08.webm](https://github.com/GradienceTeam/Submodules/assets/43273245/b46e6257-ae97-48d6-b426-840fae291662)

Thanks!